### PR TITLE
Updated workflow files

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/python-qa.yml
     with:
       lint-paths: "src"
+      lint-continue-on-error: true
 
   extended-tests:
     name: Extended QA Suite

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/python-qa.yml
     with:
       lint-paths: "src"
+      lint-continue-on-error: true
 
   publish-image:
     name: Publish Production Image

--- a/.github/workflows/python-qa.yml
+++ b/.github/workflows/python-qa.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: "requirements.txt"
+      lint-continue-on-error:
+        description: Allow lint steps to surface warnings without failing the workflow
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   qa:
@@ -39,10 +44,12 @@ jobs:
           python -m pip install flake8==6.1.0 black==24.3.0
 
       - name: Lint with flake8
+        continue-on-error: ${{ inputs.lint-continue-on-error }}
         run: |
           flake8 "${{ inputs.lint-paths }}"
 
       - name: Check formatting with Black
+        continue-on-error: ${{ inputs.lint-continue-on-error }}
         run: |
           black --check "${{ inputs.lint-paths }}"
 


### PR DESCRIPTION
This pull request updates the CI workflow configuration to provide more flexibility for linting steps. The primary change is the introduction of an option that allows linting errors to be surfaced as warnings without failing the workflow, which is useful for non-blocking code quality checks during development.

**Workflow configuration improvements:**

* Added a new input parameter `lint-continue-on-error` to the `python-qa.yml` workflow, allowing users to control whether linting errors should fail the workflow or just be reported as warnings.
* Updated the linting (`flake8`) and formatting (`Black`) steps in `python-qa.yml` to use the `continue-on-error` option based on the new input parameter.

**Integration with development and main workflows:**

* Set `lint-continue-on-error: true` in both `develop.yml` and `main.yml` workflows, ensuring that linting errors do not fail the workflow in these environments. [[1]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbR14) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R14)